### PR TITLE
Add text to support WebSocket protocols in addition to HTTPS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ not always the correct site boundary.
 
 # Domain Schemes
 
-User agents must "normalize" WebSocket schemes to HTTP(S) when determining whether a particular domain is a member of a First-Party Set. I.e. `ws://` must be mapped to `http://`, and `wss://` must be mapped to `https://`, before the lookup is performed.
+In accordance with the [Fetch](https://fetch.spec.whatwg.org/#websocket-opening-handshake) spec, user agents must "normalize" WebSocket schemes to HTTP(S) when determining whether a particular domain is a member of a First-Party Set. I.e. `ws://` must be mapped to `http://`, and `wss://` must be mapped to `https://`, before the lookup is performed.
 
 User agents need not perform this normalization on the domains in their static lists; user agents may reject static lists that include non-HTTPS domains.
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ Note that First-Party Sets also gives browsers the opportunity to group per-site
 those at `chrome://settings/content/all`) by the “first-party” boundary instead of eTLD+1, which is 
 not always the correct site boundary.
 
+# Domain Schemes
+
+User agents must "normalize" WebSocket schemes to HTTP(S) when determining whether a particular domain is a member of a First-Party Set. I.e. `ws://` must be mapped to `http://`, and `wss://` must be mapped to `https://`, before the lookup is performed.
+
+User agents need not perform this normalization on the domains in their static lists; user agents may reject static lists that include non-HTTPS domains.
+
 # Alternative designs
 
 ## Origins instead of registrable domains


### PR DESCRIPTION
This PR adds support for `wss://` domains in First-Party Sets.

Feel free to suggest a better place for this; I didn't see a section that already talked about requiring HTTPS, so there didn't seem to be a natural place already for this text.