### PR TITLE
Update explanation of Clear Site Data in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,12 @@ User agents need not perform this normalization on the domains in their static l
 # Clearing Site Data on Set Transitions
 Sites can change which First-Party Set they are a member of. We need to pay attention to these transitions so that they don’t link user identities across all the FPSs they’ve historically been in. In particular, we must ensure that a domain cannot transfer a user identifier from one First-Party Set to another when it changes its set membership.
 
-In order to achieve this, site data needs to be cleared on certain transitions. The clearing should behave like [`Clear-Site-Data: "*"`](https://www.w3.org/TR/clear-site-data/#grammardef-), which includes cookies, storage, cache, as well as execution contexts (documents, workers, etc.). We don’t differentiate between different types of site data because:
+In order to achieve this, all site data needs to be cleared on certain transitions, including cookies, storage, cache, as well as execution contexts (documents, workers, etc.). We don’t differentiate between different types of site data because:
 
  * A user identifier could be stored in any of these storage types.
  * Clearing just a few of the types would break sites that expect different types of data to be consistent with each other.
+
+The [`Clear-Site-Data: "*"`](https://www.w3.org/TR/clear-site-data/#grammardef-) specification has useful algorithms for this, but we believe it's important and safe to clear across partitions when FPS membership changes, [unlike when a site sends Clear-Site-Data](https://github.com/w3c/webappsec-clear-site-data/issues/66). 
 
 Since member sites can only add/remove themselves to/from FPSs with the consent from the owner, we look at first-party set changes as a site changing its FPS owner.
 


### PR DESCRIPTION
Update the text of how clearing site data on FPS membership change will be different from a site sending Clear-Site-Data header.