### PR TITLE
Checking user understanding of shared identity

### DIFF
--- a/ua_policy_proposal.md
+++ b/ua_policy_proposal.md
@@ -59,7 +59,7 @@ For each element of the First Party Set policy, we propose an enforcement method
 <tr>
 <td>A group identity that is easily discoverable by a users </td>
 <td>UI treatment (and co-branding in some cases)<sup>2</sup> </td>
-<td>None (solely the browser's and site author's responsibility)</td>
+<td>Conduct user surveys to determine if common identity is understandable to users</td>
 </tr>
 <tr>
 <td>Common Privacy Policy </td>


### PR DESCRIPTION
Add IEE role in surveys of users to check that they understand common identity.

(It would be impractical to leave this to the browser and site author, especially in cases where the browser and site author have a business relationship that would be influenced by FPS validity or invalidity.)

Refs #43 #48 #64 #76